### PR TITLE
Add German translation + English clarification

### DIFF
--- a/lib/languages/de.php
+++ b/lib/languages/de.php
@@ -1,0 +1,7 @@
+<?php
+
+return array(
+	'palette.new.palette'   => 'Neue Palette',
+	'palette.empty.options' => 'Bitte geben Sie Farben in den Feldoptionen an.',
+	'palette.empty.palette' => 'Die Farbpalette ist leer. Bitte wählen Sie ein Bild aus.',
+);

--- a/lib/languages/en.php
+++ b/lib/languages/en.php
@@ -2,6 +2,6 @@
 
 return array(
 	'palette.new.palette'   => 'New palette',
-	'palette.empty.options' => 'Please specify colors in the options config',
+	'palette.empty.options' => 'Please specify colors in the field options.',
 	'palette.empty.palette' => 'The color palette is empty. Please select an image.',
 );


### PR DESCRIPTION
Hello there. 👋 

I've updated the `palette.empty.options` string to add clarification where to add a palette. The developer read the readme anywhere and/or knows where to find documentation, therefore I encourage you to drop the `options` reference. It was confusing for me.

German translation also added. 